### PR TITLE
[SS-9] Fix create client command

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,8 +26,8 @@
   "devDependencies": {
     "@types/jest": "^24.0.17",
     "@types/node": "^12.12.5",
-    "jest": "^24.9.0",
-    "nodemon": "^1.19.4",
+    "jest": "^25.4.0",
+    "nodemon": "^2.0.3",
     "ts-jest": "^24.0.2",
     "ts-node": "^8.4.1",
     "tslint": "^6.0.0-beta0",
@@ -37,7 +37,7 @@
     "@types/request-promise-native": "1.0.17",
     "logacious": "0.4.0",
     "request-promise-native": "1.0.8",
-    "stream-sea-client": "3.3.0",
+    "stream-sea-client": "4.1.0",
     "ws": "7.2.0",
     "yargs": "15.0.2"
   }

--- a/src/index.ts
+++ b/src/index.ts
@@ -182,7 +182,18 @@ yargs.scriptName("stream-sea")
         .demandOption(['description'])
     }, (args:any) => {
       args = addServerConfigToArgs(args)
-      streamSea.createClient(args)
+
+      const payload = {
+        clientId: args.clientId,
+        clientSecret: args.clientSecret,
+        remoteServerHost: args.remoteServerHost,
+        remoteServerPort: args.remoteServerPort,
+        secure: args.secure,
+        targetClientId: args.appId,
+        targetClientDescription: args.description
+      }
+
+      streamSea.createClient(payload)
         .then((client) => {
           console.log('Client Identifier:', client.id)
           console.log('Client Secret:', client.secret)


### PR DESCRIPTION
Hi all,

this pr fixes the `create-client` command in conjunction with this stream sea [PR](https://github.com/Portchain/stream-sea/pull/38).

Test it manually trying to create a new client with CLI.